### PR TITLE
feat: "npm run dev" to start app by Nodemon

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ The following parameters can be set in config files or in env variables:
 ## Local Deployment
 
 - Install dependencies `npm install`
-- Start app `npm start`
+- Start app in dev mode `npm run dev` - it would use [Nodemon](https://nodemon.io/), and restart the app on every code change.
+- Or start app in prod mode `npm start`
 - App will be running at `http://localhost:3000`
 
 

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "app.js",
   "scripts": {
     "start": "node app.js",
+    "dev": "nodemon app.js",
     "lint": "standard",
     "lint:fix": "standard --fix"
   },


### PR DESCRIPTION
Not critical, just a suggestion to have such a handy command for local development.